### PR TITLE
Add apt install source

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -101,3 +101,14 @@ suites:
       - recipe[java::openjdk]
     excludes:
       - fedora-19
+  - name: apt
+    run_list:
+      - recipe[java::apt]
+    excludes:
+      - fedora-19
+      - centos-6.5
+      - centos-5.10
+    attributes:
+      java:
+        apt:
+          package: default-jre

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,13 @@ default['java']['openjdk_packages'] = []
 default['java']['accept_license_agreement'] = false
 default['java']['set_default'] = true
 
+default['java']['apt']['package'] = 'default-jre'
+default['java']['apt']['uri'] = ''
+default['java']['apt']['key'] = ''
+default['java']['apt']['components'] = []
+default['java']['apt']['keyserver'] = ''
+default['java']['apt']['distribution'] = ''
+
 # the following retry parameters apply when downloading oracle java
 default['java']['ark_retries'] = 0
 default['java']['ark_retry_delay'] = 2

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -1,0 +1,21 @@
+include_recipe 'java::set_java_home'
+
+if node['java']['java_home'].nil? or node['java']['java_home'].empty?
+  include_recipe "java::set_attributes_from_version"
+end
+
+apt_repository "java-apt-repo" do
+  uri node['java']['apt']['uri']
+  distribution node["lsb"]["codename"]
+  components node['java']['apt']['components'] if node['java']['apt']['components']
+  keyserver node['java']['apt']['keyserver'] if node['java']['apt']['keyserver']
+  key node['java']['apt']['key'] if node['java']['apt']['key']
+  not_if { node['java']['apt']['uri'].empty? }
+  only_if { platform_family?('debian') }
+end
+
+package node['java']['apt']['package'] do
+  action :install
+  not_if { node['java']['apt']['package'].empty? }
+  only_if { platform_family?('debian') }
+end


### PR DESCRIPTION
- add a simple apt install recipe
- makes it easier to stay on mainline cookbooks in wrapper cookbook situations, using things like tomcat for example.