### PR TITLE
Set connect timeout to a rationally short value (30s)

### DIFF
--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -45,7 +45,7 @@ attribute :default, :equal_to => [true, false], :default => true
 attribute :alternatives_priority, :kind_of => Integer, :default => 1
 attribute :retries, :kind_of => Integer, :default => 0
 attribute :retry_delay, :kind_of => Integer, :default => 2
-attribute :connect_timeout, :kind_of => Integer, :default => 600 # => 10 minutes
+attribute :connect_timeout, :kind_of => Integer, :default => 30 # => 30 seconds
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name


### PR DESCRIPTION
This seems like it's being treated as a download time limit, but "connect timeout" is really a limit on establishing a connection to the server.  Typically if it doesn't happen in ~30s, it's not going to happen at all.

Don't make convergences wait 10m for a connection that isn't going to happen.