### PR TITLE
Clean up for Debian

### DIFF
--- a/providers/alternatives.rb
+++ b/providers/alternatives.rb
@@ -38,8 +38,9 @@ action :set do
         description = "Add alternative for #{cmd}"
         converge_by(description) do
           Chef::Log.debug "Adding alternative for #{cmd}"
-          shell_out("rm /var/lib/alternatives/#{cmd}")
-          install_cmd = shell_out("#{alternatives_cmd} --install #{bin_path} #{cmd} #{alt_path} #{priority}")
+          Chef::Log.debug "Runnning #{alternatives_cmd} --install #{bin_path} #{cmd} #{alt_path} #{priority}"
+
+          install_cmd = shell_out("sudo #{alternatives_cmd} --install #{bin_path} #{cmd} #{alt_path} #{priority}")
           unless install_cmd.exitstatus == 0
             Chef::Application.fatal!(%Q[ set alternative failed ])
           end

--- a/recipes/default_java_symlink.rb
+++ b/recipes/default_java_symlink.rb
@@ -12,8 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+require 'pathname'
 
-link '/usr/lib/jvm/default-java' do
-  to node['java']['java_home']
-  not_if { node['java']['java_home'] == '/usr/lib/jvm/default-java' }
+default = '/usr/lib/jvm/default-java'
+
+home = node['java']['java_home']
+
+home_obj = Pathname.new(home) # compare path objects not strings
+
+target = Pathname.new(default).realpath
+# does not work, just returns the relative path in debian :
+#    target = File.readlink(default)
+
+Chef::Log.debug "Java Home #{default} resolves to #{target} wanted is #{home}"
+
+if target != home_obj
+  Chef::Log.debug "Check #{home} != #{target}"
+  link default do
+    to home
+  end
 end


### PR DESCRIPTION
Leave the deleting of alternatives to the OS, don't just delete the
file.
Also resolve the symlink to check it. If this is installed, you don't
need to do anything.
- providers/alternatives.rb:
- recipes/default_java_symlink.rb
