### PR TITLE
Add support for Mac OS X "mac_os_x" via homebrew.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,5 +5,6 @@ group :integration do
   cookbook 'apt', '~> 2.0'
   cookbook 'yum', '~> 3.3'
   cookbook 'windows', '~> 1.12'
+  cookbook 'homebrew', '~> 1.12' 
   cookbook 'test_java', path: 'test/fixtures/cookbooks/test_java'
 end

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Chef 0.10.10+ and Ohai 6.10+ for `platform_family` use.
 * FreeBSD
 * SmartOS
 * Windows
+* Mac OS X
 
 Attributes
 -----
@@ -125,7 +126,7 @@ Recipes
 Include the default recipe in a run list or recipe to get `java`.  By default
 the `openjdk` flavor of Java is installed, but this can be changed by
 using the `install_flavor` attribute. By default on Windows platform
-systems, the `install_flavor` is `windows`.
+systems, the `install_flavor` is `windows` and on Mac OS X platform systems, the `install_flavor` is `homebrew`.
 
 OpenJDK is the default because of licensing changes made upstream by
 Oracle. See notes on the `oracle` recipe below.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,8 @@ when "windows"
   default['java']['windows']['url'] = nil
   default['java']['windows']['checksum'] = nil
   default['java']['windows']['package_name'] = "Java(TM) SE Development Kit 7 (64-bit)"
+when "mac_os_x"
+  default['java']['install_flavor'] = "homebrew"
 else
   default['java']['install_flavor'] = "openjdk"
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "info@agileorbit.com"
 license           "Apache 2.0"
 description       "Installs Java runtime."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.31.0"
+version           "1.32.0"
 
 recipe "java::default", "Installs Java runtime"
 recipe "java::default_java_symlink", "Updates /usr/lib/jvm/default-java"
@@ -18,6 +18,7 @@ recipe "java::purge_packages", "Purges old Sun JDK packages"
 recipe "java::set_attributes_from_version", "Sets various attributes that depend on jdk_version"
 recipe "java::set_java_home", "Sets the JAVA_HOME environment variable"
 recipe "java::windows", "Installs the JDK on Windows"
+recipe "java::homebrew", "Installs the JDK on Mac OS X via Homebrew"
 
 %w{
     debian
@@ -34,9 +35,11 @@ recipe "java::windows", "Installs the JDK on Windows"
     suse
     xenserver
     smartos
+    mac_os_x
 }.each do |os|
   supports os
 end
 
+suggests "homebrew"
 suggests "windows"
 suggests "aws"

--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -1,0 +1,3 @@
+include_recipe 'homebrew'
+include_recipe 'homebrew::cask'
+homebrew_cask 'java7'

--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -1,3 +1,3 @@
 include_recipe 'homebrew'
 include_recipe 'homebrew::cask'
-homebrew_cask 'java7'
+homebrew_cask 'java'

--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -47,6 +47,8 @@ when "smartos"
   node.default['java']['openjdk_packages'] = ["sun-jdk#{node['java']['jdk_version']}", "sun-jre#{node['java']['jdk_version']}"]
 when "windows"
   # Do nothing otherwise we will fall through to the else and set java_home to an invalid path, causing the installer to popup a dialog
+when "macosx"
+  # Nothing. Homebrew driven.
 else
   node.default['java']['java_home'] = "/usr/lib/jvm/default-java"
   node.default['java']['openjdk_packages'] = ["openjdk-#{node['java']['jdk_version']}-jdk"]


### PR DESCRIPTION
This uses homebrew_cask to add support for Mac OS X. Homebrew requires `Berksfile` to specify `depends` for the homebrew cookbook. If there is a better way to handle this, please let me know! I'd love to get this upstream.