### PR TITLE
add openjdk-1.8.0 bin_cmds

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -58,6 +58,8 @@ if platform_family?('debian', 'rhel', 'fedora')
       bin_cmds node['java']['jdk']['6']['bin_cmds']
     when "7"
       bin_cmds node['java']['jdk']['7']['bin_cmds']
+    when "8"
+      bin_cmds node['java']['jdk']['8']['bin_cmds']
     end
     action :set
   end


### PR DESCRIPTION
RHEL and CentOS 6 have openjdk-1.8.0 packages now. This will also make the cookbook update the alternatives links to the correct bins when using these packages.