### PR TITLE
Version up, also Mac depends on homebrew.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -40,6 +40,7 @@ recipe "java::homebrew", "Installs the JDK on Mac OS X via Homebrew"
   supports os
 end
 
-suggests "homebrew"
+depends "homebrew"
+
 suggests "windows"
 suggests "aws"


### PR DESCRIPTION
Sorry for /another/ pull request, but after testing with another recipe of mine I found that "depends" homebrew is the way to go. It won't effect non-brew platforms. 

I also bumped the version number so we Mac users know we can use `~> 1.33.0`. I hope this is OK.

