### PR TITLE
Alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ By default, the extracted directory is extracted to
   boolean true or false
 - `reset_alternatives`: whether alternatives is reset
   boolean true or false
+- `use_alt_suffix`: whether '_alt' suffix is used for not default javas
+  boolean true or false
 
 #### Examples
 ```ruby

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ By default, the extracted directory is extracted to
 - `group`: group of extracted directory, set to `:owner` by default
 - `default`: whether this the default installation of this package,
   boolean true or false
+- `reset_alternatives`: whether alternatives is reset
+  boolean true or false
 
 #### Examples
 ```ruby

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "info@agileorbit.com"
 license           "Apache 2.0"
 description       "Installs Java runtime."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.32.0"
+version           "1.32.1"
 
 recipe "java::default", "Installs Java runtime"
 recipe "java::default_java_symlink", "Updates /usr/lib/jvm/default-java"

--- a/providers/alternatives.rb
+++ b/providers/alternatives.rb
@@ -38,7 +38,9 @@ action :set do
         description = "Add alternative for #{cmd}"
         converge_by(description) do
           Chef::Log.debug "Adding alternative for #{cmd}"
-          shell_out("rm /var/lib/alternatives/#{cmd}")
+          if new_resource.reset_alternatives
+            shell_out("rm /var/lib/alternatives/#{cmd}")
+          end
           install_cmd = shell_out("#{alternatives_cmd} --install #{bin_path} #{cmd} #{alt_path} #{priority}")
           unless install_cmd.exitstatus == 0
             Chef::Application.fatal!(%Q[ set alternative failed ])

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -221,6 +221,7 @@ action :install do
     bin_cmds new_resource.bin_cmds
     priority new_resource.alternatives_priority
     default new_resource.default
+    reset_alternatives new_resource.reset_alternatives
     action :set
   end
 end

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -96,7 +96,7 @@ action :install do
     app_group = new_resource.owner
   end
 
-  unless new_resource.default
+  if !new_resource.default and new_resource.use_alt_suffix
     Chef::Log.debug("processing alternate jdk")
     app_dir = app_dir  + "_alt"
     app_home = new_resource.app_home + "_alt"

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -20,6 +20,7 @@ attribute :java_location, :kind_of => String, :default => nil
 attribute :bin_cmds, :kind_of => Array, :default => nil
 attribute :default, :equal_to => [true, false], :default => true
 attribute :priority, :kind_of => Integer, :default => 1061
+attribute :reset_alternatives, :equal_to => [true, false], :default => true
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -47,6 +47,7 @@ attribute :retries, :kind_of => Integer, :default => 0
 attribute :retry_delay, :kind_of => Integer, :default => 2
 attribute :connect_timeout, :kind_of => Integer, :default => 30 # => 30 seconds
 attribute :reset_alternatives, :equal_to => [true, false], :default => true
+attribute :use_alt_suffix, :equal_to => [true, false], :default => true
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -46,6 +46,7 @@ attribute :alternatives_priority, :kind_of => Integer, :default => 1
 attribute :retries, :kind_of => Integer, :default => 0
 attribute :retry_delay, :kind_of => Integer, :default => 2
 attribute :connect_timeout, :kind_of => Integer, :default => 30 # => 30 seconds
+attribute :reset_alternatives, :equal_to => [true, false], :default => true
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name


### PR DESCRIPTION
When one uses java_ark provider in own cookbook to install several javas on a machine, there are 2 issues:
1. The provider removes alternatives configuration before installing alternative for bin cmd. So, if one has another java installed manually, or install several ones using own cookbook, only latest appear in alternatives. Another one issue here is, the latest installed one becomes active in spite of priority and while installation is in progress, the one is being installed is active.
2. #1 can be mitigated by setting default attribute to false. However, if value of 'default' attribute for a resource is false, it forces adding '_alt' suffix for directory name and this cannot be controlled. Therefore, if one decides to switch java installation from one to another, it will install two javas again. So it's nice to have a switch to control this behavior.