### PR TITLE
Alternatives improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ By default, the extracted directory is extracted to
   boolean true or false
 - `reset_alternatives`: whether alternatives is reset
   boolean true or false
+- `use_alt_suffix`: whether '_alt' suffix is used for not default javas
+  boolean true or false
 
 #### Examples
 ```ruby

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ By default, the extracted directory is extracted to
 - `group`: group of extracted directory, set to `:owner` by default
 - `default`: whether this the default installation of this package,
   boolean true or false
+- `reset_alternatives`: whether alternatives is reset
+  boolean true or false
 
 #### Examples
 ```ruby

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,8 @@ default['java']['accept_license_agreement'] = false
 default['java']['set_default'] = true
 default['java']['alternatives_priority'] = 1062
 default['java']['set_etc_environment'] = false
+default['java']['use_alt_suffix'] = true
+default['java']['reset_alternatives'] = true
 
 # the following retry parameters apply when downloading oracle java
 default['java']['ark_retries'] = 0

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "info@agileorbit.com"
 license           "Apache 2.0"
 description       "Installs Java runtime."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.32.0"
+version           "1.32.1"
 
 recipe "java::default", "Installs Java runtime"
 recipe "java::default_java_symlink", "Updates /usr/lib/jvm/default-java"

--- a/providers/alternatives.rb
+++ b/providers/alternatives.rb
@@ -31,9 +31,22 @@ action :set do
         Chef::Log.debug "Skipping setting alternative for #{cmd}. Command #{alt_path} does not exist."
         next
       end
-
-      # install the alternative if needed
+      
+      alternative_exists_same_prio = shell_out("#{alternatives_cmd} --display #{cmd} | grep #{alt_path} | grep 'priority #{priority}$'").exitstatus == 0
       alternative_exists = shell_out("#{alternatives_cmd} --display #{cmd} | grep #{alt_path}").exitstatus == 0
+      # remove alternative is prio is changed and install it with new prio 
+      if alternative_exists and !alternative_exists_same_prio
+        description = "Removing alternative for #{cmd} with old prio"
+        converge_by(description) do
+          Chef::Log.debug "Removing alternative for #{cmd} with old priority"
+          remove_cmd = shell_out("#{alternatives_cmd} --remove #{cmd} #{alt_path}")
+          alternative_exists = false
+          unless remove_cmd.exitstatus == 0
+            Chef::Application.fatal!(%Q[ remove alternative failed ])
+          end
+        end
+      end
+      # install the alternative if needed
       unless alternative_exists
         description = "Add alternative for #{cmd}"
         converge_by(description) do
@@ -43,7 +56,7 @@ action :set do
           end
           install_cmd = shell_out("#{alternatives_cmd} --install #{bin_path} #{cmd} #{alt_path} #{priority}")
           unless install_cmd.exitstatus == 0
-            Chef::Application.fatal!(%Q[ set alternative failed ])
+            Chef::Application.fatal!(%Q[ install alternative failed ])
           end
         end
         new_resource.updated_by_last_action(true)

--- a/providers/alternatives.rb
+++ b/providers/alternatives.rb
@@ -38,7 +38,9 @@ action :set do
         description = "Add alternative for #{cmd}"
         converge_by(description) do
           Chef::Log.debug "Adding alternative for #{cmd}"
-          shell_out("rm /var/lib/alternatives/#{cmd}")
+          if new_resource.reset_alternatives
+            shell_out("rm /var/lib/alternatives/#{cmd}")
+          end
           install_cmd = shell_out("#{alternatives_cmd} --install #{bin_path} #{cmd} #{alt_path} #{priority}")
           unless install_cmd.exitstatus == 0
             Chef::Application.fatal!(%Q[ set alternative failed ])

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -221,6 +221,7 @@ action :install do
     bin_cmds new_resource.bin_cmds
     priority new_resource.alternatives_priority
     default new_resource.default
+    reset_alternatives new_resource.reset_alternatives
     action :set
   end
 end

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -96,7 +96,7 @@ action :install do
     app_group = new_resource.owner
   end
 
-  unless new_resource.default
+  if !new_resource.default and new_resource.use_alt_suffix
     Chef::Log.debug("processing alternate jdk")
     app_dir = app_dir  + "_alt"
     app_home = new_resource.app_home + "_alt"

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -60,6 +60,8 @@ java_ark "jdk" do
   retries node['java']['ark_retries']
   retry_delay node['java']['ark_retry_delay']
   connect_timeout node['java']['ark_timeout']
+  use_alt_suffix node['java']['use_alt_suffix']
+  reset_alternatives node['java']['reset_alternatives']
   action :install
 end
 

--- a/recipes/oracle_i386.rb
+++ b/recipes/oracle_i386.rb
@@ -58,6 +58,8 @@ java_ark "jdk-alt" do
   bin_cmds bin_cmds
   retries node['java']['ark_retries']
   retry_delay node['java']['ark_retries']
+  use_alt_suffix node['java']['use_alt_suffix']
+  reset_alternatives node['java']['reset_alternatives']
   action :install
   default false
 end

--- a/resources/alternatives.rb
+++ b/resources/alternatives.rb
@@ -20,6 +20,7 @@ attribute :java_location, :kind_of => String, :default => nil
 attribute :bin_cmds, :kind_of => Array, :default => nil
 attribute :default, :equal_to => [true, false], :default => true
 attribute :priority, :kind_of => Integer, :default => 1061
+attribute :reset_alternatives, :equal_to => [true, false], :default => true
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -47,6 +47,7 @@ attribute :retries, :kind_of => Integer, :default => 0
 attribute :retry_delay, :kind_of => Integer, :default => 2
 attribute :connect_timeout, :kind_of => Integer, :default => 30 # => 30 seconds
 attribute :reset_alternatives, :equal_to => [true, false], :default => true
+attribute :use_alt_suffix, :equal_to => [true, false], :default => true
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -46,6 +46,7 @@ attribute :alternatives_priority, :kind_of => Integer, :default => 1
 attribute :retries, :kind_of => Integer, :default => 0
 attribute :retry_delay, :kind_of => Integer, :default => 2
 attribute :connect_timeout, :kind_of => Integer, :default => 30 # => 30 seconds
+attribute :reset_alternatives, :equal_to => [true, false], :default => true
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name


### PR DESCRIPTION
When one uses java_ark provider in own cookbook to install several javas on a machine, there are 2 issues:
1. The provider removes alternatives configuration before installing alternative for bin cmd. So, if one has another java installed manually, or install several ones using own cookbook, only latest appear in alternatives. Another one issue here is, the latest installed one becomes active in spite of priority and while installation is in progress, the one is being installed is active.
2. #1 can be mitigated by setting default attribute to false. However, if value of 'default' attribute for a resource is false, it forces adding '_alt' suffix for directory name and this cannot be controlled. Therefore, if one decides to switch java installation from one to another, it will install two javas again. So it's nice to have a switch to control this behavior.
3. If priority of alternative gets changed, and the provider installs already existing alternative (but with another prio), the alternative switches to manual mode if it was auto.

This change corrects all these issues. But all defaults are set that way, so original behavior remains.