### PR TITLE
Install Oracle JDK 8 via RPM

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -137,3 +137,12 @@ suites:
         jdk_version: 7
         oracle: 
           accept_oracle_download_terms: true
+  - name: oracle-rpm-8
+    run_list:
+      - recipe[java]
+    attributes:
+      java:
+        install_flavor: oracle_rpm
+        jdk_version: 8
+        oracle: 
+          accept_oracle_download_terms: true

--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ repositories.
 It also uses the `alternatives` system on RHEL families to set
 the default Java.
 
+While public YUM repos for Oracle Java 7 and prior are available, 
+you need to download the RPMs manually for Java 8 and make 
+your own internal repository. This must be done to use this recipe to
+install Oracle Java 8 via RPM. You will also likely need to set
+`node['java']['oracle_rpm']['package_name']` to `jdk1.8.0_40`, 
+replacing `40` with the most current version in your local repo. 
+
 ### windows
 
 Because there is no easy way to pull the java msi off oracle's site,

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,8 +19,10 @@
 #
 
 if node['java']['install_flavor'] != 'windows'
-  if node['java']['jdk_version'].to_i == 8 and node['java']['install_flavor'] != 'oracle'
-    Chef::Application.fatal!("JDK 8 is currently only provided with the Oracle JDK")
+  if node['java']['jdk_version'].to_i == 8 
+    unless node['java']['install_flavor'] == 'oracle' or node['java']['install_flavor'] == 'oracle_rpm'
+      Chef::Application.fatal!("JDK 8 is currently only provided with the Oracle JDK")
+    end
   end
 end
 

--- a/recipes/oracle_rpm.rb
+++ b/recipes/oracle_rpm.rb
@@ -41,7 +41,7 @@ if platform_family?('rhel', 'fedora') and node['java']['set_default']
     end
 
     code <<-EOH.gsub(/^\s+/, '')
-      update-alternatives --install /usr/bin/java java #{java_location} 1061 \
+      update-alternatives --install /usr/bin/java java #{java_location} #{node['java']['alternatives_priority']} \
       #{slave_lines} && \
       update-alternatives --set java #{java_location}
     EOH

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -96,6 +96,19 @@ describe 'java::default' do
     end
   end
 
+  context 'Oracle JDK 8 RPM' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.node.set['java']['install_flavor'] = 'oracle_rpm'
+      runner.node.set['java']['jdk_version'] = '8'
+      runner.converge(described_recipe)
+    end
+
+    it 'should not error' do
+      expect{chef_run}.to_not raise_error
+    end
+  end
+
   context 'OpenJDK 8' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new


### PR DESCRIPTION
Allow Oracle JDK 8 via RPM. Includes a note in the README about the requirement that you maintain your own yum repo for this to actually work since Oracle doesn't provide a public repo for 8. As such, I didn't add a suite to test kitchen since it wouldn't work outside my network. ChefSpec test added, however. 