### PR TITLE
Java 8 Windows Installer Fix (java_home // INSTALLDIR)

### DIFF
--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -54,8 +54,8 @@ if node['java'].attribute?("java_home")
   java_home_win = win_friendly_path(node['java']['java_home'])
   # The EXE installer expects escaped quotes, so we need to double escape
   # them here. The final string looks like :
-  # /v"/qn INSTALLDIR=\"C:\Program Files\Java\""
-  additional_options = "/v\"/qn INSTALLDIR=\\\"#{java_home_win}\\\"\""
+  # INSTALLDIR=\"C:\Program Files\Java\""
+  additional_options = "INSTALLDIR=\"#{java_home_win}\""
 
   env "JAVA_HOME" do
     value java_home_win


### PR DESCRIPTION
Specifying "Java Home" breaks the installation of Java 8 on Windows.  
***Example***
```
default['java']['java_home'] = 'C:\Program Files\Java\jdk1.8.0_45'
```
Several solutions to this problem exist.

In my testing it was sufficient to simply change the appropriate line as such:
```
additional_options = "INSTALLDIR=\"#{java_home_win}\""
```
This made for a backwards compatible change (pre 8, and 8 installer).  I performed validation testing with the installers for 7u45 jre, 8u45 jre, 8u45 jdk.This solution should also simplify the escaped quoting that's occurring.  The above version works with and without spaces in the name.

