### PR TITLE
Fix typo in platform family spelling for OS X

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -63,24 +63,33 @@ platforms:
   - name: fedora-20
     driver:
       box: opscode-fedora-20
+  - name: macosx-10.10
+    driver:
+      box: macosx-10.10
+    run_list:
+    - recipe[homebrew]
 
 suites:
   - name: openjdk
     excludes:
       - fedora-19
       - fedora-20
+      - macosx-10.10
     run_list:
       - recipe[java::default]
   - name: openjdk-7
     excludes:
       - ubuntu-10.04
       - debian-6.0.8
+      - macosx-10.10
     run_list:
       - recipe[java::default]
     attributes:
       java:
         jdk_version: "7"
   - name: oracle
+    excludes:
+      - macosx-10.10
     run_list:
       - recipe[test_java::default]
       - recipe[java::default]
@@ -92,6 +101,8 @@ suites:
             enabled: true
         install_flavor: oracle
   - name: oracle-7
+    excludes:
+      - macosx-10.10
     run_list:
       - recipe[test_java::default]
       - recipe[java::default]
@@ -104,6 +115,8 @@ suites:
             enabled: true
         install_flavor: oracle
   - name: oracle-8
+    excludes:
+      - macosx-10.10
     run_list:
       - recipe[test_java::default]
       - recipe[java::default]
@@ -116,6 +129,8 @@ suites:
             enabled: true
         install_flavor: oracle
   - name: oracle-direct
+    excludes:
+      - macosx-10.10
     run_list:
       - recipe[java::oracle]
     attributes:
@@ -128,7 +143,10 @@ suites:
     excludes:
       - fedora-19
       - fedora-20
+      - macosx-10.10
   - name: oracle-rpm
+    excludes:
+      - macosx-10.10
     run_list:
       - recipe[java]
     attributes:
@@ -137,3 +155,24 @@ suites:
         jdk_version: 7
         oracle: 
           accept_oracle_download_terms: true
+  - name: homebrew
+    excludes:
+      - ubuntu-14.04
+      - ubuntu-13.10
+      - ubuntu-12.04
+      - ubuntu-10.04
+      - debian-6.0.8
+      - debian-7.6
+      - debian-7.4
+      - centos-7.0
+      - centos-6.5
+      - centos-5.10
+      - fedora-19
+      - fedora-20
+    run_list:
+      - recipe[test_java::default]
+      - recipe[java]
+    attributes:
+      java:
+        install_flavor: homebrew
+        jdk_version: 8

--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -47,7 +47,7 @@ when "smartos"
   node.default['java']['openjdk_packages'] = ["sun-jdk#{node['java']['jdk_version']}", "sun-jre#{node['java']['jdk_version']}"]
 when "windows"
   # Do nothing otherwise we will fall through to the else and set java_home to an invalid path, causing the installer to popup a dialog
-when "macosx"
+when "mac_os_x"
   # Nothing. Homebrew driven.
 else
   node.default['java']['java_home'] = "/usr/lib/jvm/default-java"

--- a/test/integration/homebrew/bats/verify_homebrew.bats
+++ b/test/integration/homebrew/bats/verify_homebrew.bats
@@ -1,0 +1,44 @@
+@test "installs the correct version of the jdk" {
+  # When:
+  run java -version 2>&1
+
+  # Then:
+  [[ "${lines[0]}" =~ $(echo 'java version "1\.8\.[0-9_]+"') ]] && true || false
+}
+
+@test "installs JAVA 8" {
+  # When:
+  run /usr/libexec/java_home -v '1.8*' > /dev/null 2>&1
+
+  # Then:
+  [ "$status" -eq 0 ]
+}
+
+@test "does not install JAVA 7" {
+  # When:
+  run /usr/libexec/java_home -v '1.7*' > /dev/null 2>&1
+
+  # Then:
+  [ "$status" -eq 2 ]
+}
+
+@test "enables JAVA_HOME to be properly set with the java_home util" {
+  # When:
+  run /usr/libexec/java_home -v '1.8*'
+
+  # Then:
+  [ -n "$output" ]
+}
+
+@test "properly links jar" {
+  # Expect:
+  [ -L /usr/bin/jar ]
+}
+
+@test "does not installs JCE" {
+  # When:
+  run java -jar /tmp/UnlimitedSupportJCETest.jar
+
+  # Then:
+  [ "$output" = "isUnlimitedSupported=FALSE, strength: 128" ]
+}


### PR DESCRIPTION
Working with the cookbook, I came up with a typo in `set_attributes_from_version.rb`
and wanted to fix it.

Then the contributing guidelines reminded me to add some tests.
So, I added a `macosx` platform and a `homebrew` test suite to
the existing kitchen tests, with proper exclusions because the
`homebrew` test suite only makes sense on OS X. Plus, the
`hombrew` flavor is the only one supported on this platform.

The vagrant box I use to run the kitchen test is the `github:chef/bento`
one including the patch I just submitted there as PR. I ran it successfully
on the latest OSX 10.10.4.

In the process, I found out added some BATS tests for the `homebrew`
flavor, inspired by those for the `oracle-8` flavor.