### PR TITLE
add source_url to metadata.rb to make it easier to find

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,7 @@ license           "Apache 2.0"
 description       "Installs Java runtime."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "1.32.1"
+source_url       'https://github.com/agileorbit-cookbooks/java'
 
 recipe "java::default", "Installs Java runtime"
 recipe "java::default_java_symlink", "Updates /usr/lib/jvm/default-java"


### PR DESCRIPTION
chef supermarket uses this metadata attribute to advertise the github repo, making it easier for community members to offer up improvements and fixes.