### PR TITLE
Add ubuntu ppa (allows OpenJDK 8)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -67,6 +67,15 @@ suites:
     attributes:
       java:
         jdk_version: "7"
+  - name: openjdk-8
+    excludes:
+      - debian-7.6
+      - debian-6.0.8
+    run_list:
+      - recipe[java::default]
+    attributes:
+      java:
+        jdk_version: "7"
   - name: oracle
     run_list:
       - recipe[test_java::default]

--- a/metadata.rb
+++ b/metadata.rb
@@ -40,6 +40,8 @@ recipe "java::homebrew", "Installs the JDK on Mac OS X via Homebrew"
   supports os
 end
 
+depends "apt"
+
 suggests "homebrew"
 suggests "windows"
 suggests "aws"

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -42,6 +42,14 @@ if platform_requires_license_acceptance?
   end
 end
 
+if node['platform'] == 'ubuntu'
+  include_recipe 'apt'
+  apt_repository 'openjdk-r-ppa' do
+    uri 'ppa:openjdk-r'
+    distribution node['lsb']['codename']
+  end
+end
+
 node['java']['openjdk_packages'].each do |pkg|
   package pkg do
     version node['java']['openjdk_version'] if node['java']['openjdk_version']

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -104,7 +104,7 @@ describe 'java::default' do
       runner.converge(described_recipe)
     end
 
-    it 'should error' do
+    it 'should not error' do
       expect{chef_run}.to_not raise_error
     end
   end

--- a/test/integration/openjdk-8/bats/verify_openjdk-8.bats
+++ b/test/integration/openjdk-8/bats/verify_openjdk-8.bats
@@ -1,0 +1,14 @@
+@test "installs the correct version of the jdk" {
+  java -version 2>&1 | grep 1.8
+}
+
+@test "properly sets JAVA_HOME environment variable" {
+  source /etc/profile.d/jdk.sh
+  run test -d $JAVA_HOME
+  [ "$status" -eq 0 ]
+}
+
+@test "properly links jar" {
+  run test -L /usr/bin/jar
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
The Ubuntu OpenJDK maintainers have a PPA called "openjdk-r-ppa" which provides OpenJDK 8 for Ubuntu 12.04 and 14.04.

This did require adding 'apt' cookbook as a concrete dependency.

I converged Ubuntu 14.04 manually with no problems, am a little constrained on my kitchen testing capacity with several parallel projects today, but will happily run the full kitchen when I get a chance.

I ran rspec tests, which seemed to pass as much as before, there is a test I patched the output for, "OpenJDK 8", which seems to verify that the chef_run does not fail, but prints "should fail".

I'm happy to write further tests if needed, but wanted to kick open a PR and start a conversation - this is a  block of code I have to add to all of my wrapper cookbooks with consume the java cookbook currently, is a non-fringe source of packages, and seems reasonable to me, but I'm open to feedback.

TIA!