### PR TITLE
Remove non-persistent set-env-java-home block

### DIFF
--- a/recipes/set_java_home.rb
+++ b/recipes/set_java_home.rb
@@ -16,13 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ruby_block  "set-env-java-home" do
-  block do
-    ENV["JAVA_HOME"] = node['java']['java_home']
-  end
-  not_if { ENV["JAVA_HOME"] == node['java']['java_home'] }
-end
-
 directory "/etc/profile.d" do
   mode 00755
 end


### PR DESCRIPTION
This environment variable only gets created within the chef-client process.
It isn't persisted after the chef run. It therefore gets executed on every
chef client run, reporting that resources have been updated.

Since it isn't persisted it probably isn't needed here.