### PR TITLE
allows to use IAM role for S3 access

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ the .tar.gz.
 * `node['java']['windows']['checksum']` - The checksum for the package to
   download on Windows machines (default is nil, which does not perform
   checksum validation)
+* `node['java']['windows']['use_iam_role']` - If set to true and `node['java']['windows']['url']` points to S3 bucket IAM role will be used to fetch the file.
 * `node['java']['ibm']['url']` - The URL which to download the IBM
   JDK/SDK. See the `ibm` recipe section below.
 * `node['java']['ibm']['accept_ibm_download_terms']` - Indicates that

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -29,7 +29,7 @@ aws_secret_access_key = node['java']['windows']['aws_secret_access_key']
 uri = ::URI.parse(node['java']['windows']['url'])
 cache_file_path = File.join(Chef::Config[:file_cache_path], File.basename(::URI.unescape(uri.path)))
 
-if aws_access_key_id && aws_secret_access_key
+if aws_access_key_id && aws_secret_access_key || node['java']['windows']['use_iam_role']
   include_recipe 'aws::default'  # install right_aws gem for aws_s3_file
 
   aws_s3_file cache_file_path do


### PR DESCRIPTION
Allows to use IAM role for S3 access when node['java']['windows']['use_iam_role'] is set to true.
aws cookbook does not need any changes for this.
