### PR TITLE
Create java home dir even if top level doesn't exist(Eg mkdir_p instead of mkdir)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "info@agileorbit.com"
 license           "Apache 2.0"
 description       "Installs Java runtime."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.35.0"
+version           "1.35.1"
 
 recipe "java::default", "Installs Java runtime"
 recipe "java::default_java_symlink", "Updates /usr/lib/jvm/default-java"

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -112,7 +112,7 @@ action :install do
     unless ::File.exists?(app_root)
       description = "create dir #{app_root} and change owner to #{new_resource.owner}:#{app_group}"
       converge_by(description) do
-          FileUtils.mkdir app_root, :mode => new_resource.app_home_mode
+          FileUtils.mkdir_p app_root, :mode => new_resource.app_home_mode
           FileUtils.chown new_resource.owner, app_group, app_root
       end
     end


### PR DESCRIPTION
Currently it will fail if the top level directory is not there. 