### PR TITLE
Fix berks url and remove apt

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,8 @@
-source "https://supermarket.getchef.com"
+source 'https://supermarket.chef.io'
+
 metadata
 
 group :integration do
-  cookbook 'apt', '~> 2.0'
   cookbook 'yum', '~> 3.3'
   cookbook 'windows', '~> 1.12'
   cookbook 'homebrew', '~> 1.12' 


### PR DESCRIPTION
There's no need to define apt in the berksfile since the berksfile
sources metadata and apt is already in the metadata (also without a
version constraint).