### PR TITLE
Update gitignore and add a chefignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+*.gem
+.zero-knife.rb
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+Gemfile.lock
+_Store
 *~
 *#
 .#*
@@ -7,15 +23,24 @@
 *.tmp
 *.bk
 *.bkup
-.kitchen.local.yml
-Berksfile.lock
-Gemfile.lock
+.ruby-version
+.ruby-gemset
+.rvmrc
 
-.bundle/
-.cache/
-.kitchen/
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+.idea
+
+#chef stuff
+Berksfile.lock
+.kitchen
+.kitchen.local.yml
+vendor/
+.coverage/
+
+#vagrant stuff
 .vagrant/
 .vagrant.d/
-bin/
-tmp/
-vendor/
+.kitchen/

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,99 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+test/*
+spec/*
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml


### PR DESCRIPTION
Use the standard gitignore used in Chef managed cookbooks and add a
chefignore file which limits the files uploaded to the chef server to
speed up chef pulling down the artifacts.