### PR TITLE
Update test gems and test via ChefDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,28 @@
-language: ruby
-bundler_args: --without integration
-rvm:
-    - 2.1.4
-script: 
-    - bundle exec rake travis
+# Use Travis's cointainer based infrastructure
+sudo: false
+addons:
+  apt:
+    sources:
+      - chef-current-precise
+    packages:
+      - chefdk
+
+# Don't `bundle install`
+install: echo "skip bundle install"
+
+branches:
+  only:
+    - master
+
+# Ensure we make ChefDK's Ruby the default
+before_script:
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+  # We have to install chef-sugar for ChefSpec
+  - /opt/chefdk/embedded/bin/chef gem install chef-sugar
+script:
+  - /opt/chefdk/embedded/bin/chef --version
+  - /opt/chefdk/embedded/bin/rubocop --version
+  - /opt/chefdk/embedded/bin/rubocop
+  - /opt/chefdk/embedded/bin/foodcritic --version
+  - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
+  - /opt/chefdk/embedded/bin/rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,23 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'berkshelf', '~> 3.2.1'
-
-group :test do
-  gem 'foodcritic', '~> 4.0.0'
-  gem 'rubocop', '~> 0.27.1'
-  gem 'chefspec', '~> 4.1.1'
+group :rake do
+  gem 'rake'
 end
 
-group :integration do
-  gem 'test-kitchen', '~> 1.2.1'
-  gem 'kitchen-vagrant', '~> 0.15'
+group :lint do
+  gem 'foodcritic', '~> 5.0'
+  gem 'rubocop', '~> 0.34'
+end
+
+group :unit do
+  gem 'berkshelf',  '~> 4.0'
+  gem 'chefspec',   '~> 4.4'
+end
+
+group :kitchen_common do
+  gem 'test-kitchen', '~> 1.4'
+end
+
+group :kitchen_vagrant do
+  gem 'kitchen-vagrant', '~> 0.19'
 end


### PR DESCRIPTION
Test via a complete chef install in Travis vs. doing gem installs which
might not actually match that of the client or server installs.  This is
the preferred test infra install method now.