### PR TITLE
Require chef 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ run_list(
 Requirements
 -----
 
-Chef 0.10.10+ and Ohai 6.10+ for `platform_family` use.
+Chef 11+
 
 ### Platform
 


### PR DESCRIPTION
Chef 10 is quite EoL at this point and 100% unsupported.  The minimum
supported chef release for this cookbook should be 11.