### PR TITLE
Extract files to temp directory instead of Chef::Config['file_cache_path']

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -144,26 +144,19 @@ action :install do
         case tarball_name
         when /^.*\.bin/
           cmd = shell_out(
-            %( cd "#{Chef::Config[:file_cache_path]}";
-                bash ./#{tarball_name} -noregister
-              ))
-          unless cmd.exitstatus == 0
-            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
-          end
+            %( cd "#{Chef::Config[:file_cache_path]}"; bash ./#{tarball_name} -noregister )
+          )
         when /^.*\.zip/
           cmd = shell_out(
             %( unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{tmp_dir}" )
           )
-          unless cmd.exitstatus == 0
-            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
-          end
         when /^.*\.(tar.gz|tgz)/
           cmd = shell_out(
-            %( tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{tmp_dir}" --no-same-owner)
+            %( tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{tmp_dir}" --no-same-owner )
           )
-          unless cmd.exitstatus == 0
-            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
-          end
+        end
+        unless cmd.exitstatus == 0
+          Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
         end
 
         cmd = shell_out(

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -136,43 +136,46 @@ action :install do
       r.run_action(:create_if_missing)
     end
 
-    description = "extract compressed data into Chef file cache path and
+    description = "extract compressed data into a temp directory and
                     move extracted data to #{app_dir}"
     converge_by(description) do
-      case tarball_name
-      when /^.*\.bin/
-        cmd = shell_out(
-          %( cd "#{Chef::Config[:file_cache_path]}";
-              bash ./#{tarball_name} -noregister
-            ))
-        unless cmd.exitstatus == 0
-          Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
+      require 'tmpdir'
+      Dir.mktmpdir do |tmp_dir|
+        case tarball_name
+        when /^.*\.bin/
+          cmd = shell_out(
+            %( cd "#{Chef::Config[:file_cache_path]}";
+                bash ./#{tarball_name} -noregister
+              ))
+          unless cmd.exitstatus == 0
+            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
+          end
+        when /^.*\.zip/
+          cmd = shell_out(
+            %( unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{tmp_dir}" )
+          )
+          unless cmd.exitstatus == 0
+            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
+          end
+        when /^.*\.(tar.gz|tgz)/
+          cmd = shell_out(
+            %( tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{tmp_dir}" --no-same-owner)
+          )
+          unless cmd.exitstatus == 0
+            Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
+          end
         end
-      when /^.*\.zip/
+
         cmd = shell_out(
-          %( unzip "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -d "#{Chef::Config[:file_cache_path]}" )
+          %( mv "#{tmp_dir}/#{app_dir_name}" "#{app_dir}" )
         )
         unless cmd.exitstatus == 0
-          Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
+          Chef::Application.fatal!(%( Command \' mv "#{tmp_dir}/#{app_dir_name}" "#{app_dir}" \' failed ))
         end
-      when /^.*\.(tar.gz|tgz)/
-        cmd = shell_out(
-          %( tar xvzf "#{Chef::Config[:file_cache_path]}/#{tarball_name}" -C "#{Chef::Config[:file_cache_path]}" --no-same-owner)
-        )
-        unless cmd.exitstatus == 0
-          Chef::Application.fatal!("Failed to extract file #{tarball_name}!")
-        end
+
+        # change ownership of extracted files
+        FileUtils.chown_R new_resource.owner, app_group, app_root
       end
-
-      cmd = shell_out(
-        %( mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" )
-      )
-      unless cmd.exitstatus == 0
-        Chef::Application.fatal!(%( Command \' mv "#{Chef::Config[:file_cache_path]}/#{app_dir_name}" "#{app_dir}" \' failed ))
-        end
-
-      # change ownership of extracted files
-      FileUtils.chown_R new_resource.owner, app_group, app_root
     end
     new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
Extract the file contents of the downloaded java archive into the system's temp directory, rather than `Chef::Config['file_cache_path']`.

This is for two reasons:
1. currently the Chef run fails when the `Chef::Config['file_cache_path']` is located on a VirtualBox shared folder (e.g. when using [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier)). It's not immediately obvious from the logs but the root cause is [this VirtualBox restriction](http://superuser.com/a/446908) 
2. we may want to keep the `Chef::Config['file_cache_path']` clean (i.e. we don't need to cache both the archive AND it's extracted contents)
