### PR TITLE
Set the oracle download terms cookie when installing on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,10 @@ replacing `40` with the most current version in your local repo.
 
 ### windows
 
-Because there is no easy way to pull the java msi off oracle's site,
-this recipe requires you to host it internally on your own http repo.
+Because as of 26 March 2012 you can no longer directly download the 
+JDK msi from Oracle's website without using a special cookie. This recipe
+requires you to set `node['java']['oracle']['accept_oracle_download_terms']` 
+to true or host it internally on your own http repo or s3 bucket.
 
 **IMPORTANT NOTE**
 

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -42,6 +42,18 @@ if aws_access_key_id && aws_secret_access_key
     action :create
   end
 else
+  ruby_block do
+    block do
+      # Chef::REST became Chef::HTTP in chef 11
+      cookie_jar = Chef::REST::CookieJar if defined?(Chef::REST::CookieJar)
+      cookie_jar = Chef::HTTP::CookieJar if defined?(Chef::HTTP::CookieJar)
+
+      cookie_jar.instance["#{uri.host}:#{uri.port}"] = "oraclelicense=accept-securebackup-cookie"
+    end
+
+    only_if { node['java']['oracle']['accept_oracle_download_terms'] }
+  end
+
   remote_file cache_file_path do
     checksum pkg_checksum if pkg_checksum
     source node['java']['windows']['url']

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -48,7 +48,7 @@ else
       cookie_jar = Chef::REST::CookieJar if defined?(Chef::REST::CookieJar)
       cookie_jar = Chef::HTTP::CookieJar if defined?(Chef::HTTP::CookieJar)
 
-      cookie_jar.instance["#{uri.host}:#{uri.port}"] = "oraclelicense=accept-securebackup-cookie"
+      cookie_jar.instance["#{uri.host}:#{uri.port}"] = 'oraclelicense=accept-securebackup-cookie'
     end
 
     only_if { node['java']['oracle']['accept_oracle_download_terms'] }
@@ -84,7 +84,7 @@ if node['java'].attribute?('java_home')
   end
 end
 
-if node['java']['windows'].attribute?('public_jre_home') && node['java']['windows']['public_jre_home'] 
+if node['java']['windows'].attribute?('public_jre_home') && node['java']['windows']['public_jre_home']
   java_publicjre_home_win = win_friendly_path(node['java']['windows']['public_jre_home'])
   additional_options = "#{additional_options} /INSTALLDIRPUBJRE=\"#{java_publicjre_home_win}\""
 end


### PR DESCRIPTION
I have not added any tests, because it seems like there is no test kitchen for windows set up at the moment and it sounds like a pain to get working.  If you think that we should set up integration tests for windows I am happy to do so?