### PR TITLE
Distinguishing the Java version for installing on the Mac OS X

### DIFF
--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -1,3 +1,5 @@
 include_recipe 'homebrew'
 include_recipe 'homebrew::cask'
-homebrew_cask 'java'
+
+homebrew_tap 'caskroom/versions'
+homebrew_cask "java#{node['java']['jdk_version']}"


### PR DESCRIPTION
Install Java on the Mac OS X with version `node['java']['jdk_version']`