### PR TITLE
Chefspec test coverage report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'libraries'))
 require 'helpers'
 require 'chefspec'
 require 'chefspec/berkshelf'
+ChefSpec::Coverage.start!
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
I was playing around looking into this cookbook and noticed that the coverage report wasn't there.

Now when you run `bundle exec rake unit` you'll get a report of the percentage of the unit tests coverage for the cookbook.