### PR TITLE
ruby block must be named. 

### DIFF
--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -42,7 +42,7 @@ if aws_access_key_id && aws_secret_access_key
     action :create
   end
 else
-  ruby_block do
+  ruby_block 'Enalbe Accessing cookies' do
     block do
       # Chef::REST became Chef::HTTP in chef 11
       cookie_jar = Chef::REST::CookieJar if defined?(Chef::REST::CookieJar)

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -42,7 +42,7 @@ if aws_access_key_id && aws_secret_access_key
     action :create
   end
 else
-  ruby_block 'Enalbe Accessing cookies' do
+  ruby_block 'Enable Accessing cookies' do
     block do
       # Chef::REST became Chef::HTTP in chef 11
       cookie_jar = Chef::REST::CookieJar if defined?(Chef::REST::CookieJar)


### PR DESCRIPTION
Chef 12.4.3 throws an error that ruby block must be named