### PR TITLE
Updare ibm_jdk.installer.properties.erb for IBM JDK 1.8

### DIFF
--- a/templates/default/ibm_jdk.installer.properties.erb
+++ b/templates/default/ibm_jdk.installer.properties.erb
@@ -1,3 +1,4 @@
+LICENSE_ACCEPTED=<%= node['java']['accept_license_agreement'] %>
 INSTALLER_UI=silent
 USER_INSTALL_DIR=<%= node['java']['java_home'] %>
 -fileOverwrite_<%= node['java']['java_home'] %>_uninstall/uninstall.lax=Yes


### PR DESCRIPTION
Without the LICENSE_ACCEPTED line, installation of IBM JDK 8 appears to be success but nothing is installed on /usr/lib/jvm/java-1.8.0.  Here's the snippet of .kitchen.yml.

...
suites:
  - name: default
    run_list:
      - recipe[java::default]
    attributes:
      java:
        install_flavor: ibm
        jdk_version: 8
        accept_license_agreement: true
        ibm:
          accept_ibm_download_terms: true
          url: "http://repo.example.com/repo/java/ibm-java-x86_64-sdk-8.0-2.10.bin"
          checksum: 1081b8d43bad2942d6cd9662e3d7131542c73522574e897c2ab18a82504e7c99