### PR TITLE
Install OpenJDK from distribution if Ubuntu version >= 15.10

### DIFF
--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -40,7 +40,7 @@ if platform_requires_license_acceptance?
   end
 end
 
-if node['platform'] == 'ubuntu'
+if node['platform'] == 'ubuntu' && node['platform_version'] < '15.10'
   include_recipe 'apt'
   apt_repository 'openjdk-r-ppa' do
     uri 'ppa:openjdk-r'


### PR DESCRIPTION
Hi there,

since Ubuntu 15.10 it is no longer needed to include an external ppa-repository for OpenJDK 8. (Ubuntu 16.04 has [OpenJDK 8](http://packages.ubuntu.com/search?keywords=openjdk-8-jdk) in `main` and  [OpenJDK 9](http://packages.ubuntu.com/search?keywords=openjdk-9-jdk) in `universe`).

If you still want to go with the PPA, I would suggest to add an attribute to disable the PPA for everyone who doesn't want to (or can't) use an external PPA.

Cheers,
Jan
