### PR TITLE
fix openjdk version logic for freebsd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,7 +49,11 @@ platforms:
   - name: fedora-23
     driver:
       box: box-cutter/fedora21
-
+  - name: freebsd-10.2
+    driver:
+      box: box-cutter/freebsd102
+    run_list:
+    - recipe[freebsd_bash]
 suites:
   - name: openjdk-6
     includes:
@@ -71,6 +75,7 @@ suites:
       - ubuntu-12.04
       - ubuntu-14.04
       - ubuntu-16.04
+      - freebsd-10.2
     run_list:
       - recipe[java::default]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -7,4 +7,5 @@ group :integration do
   cookbook 'windows'
   cookbook 'homebrew'
   cookbook 'test_java', path: 'test/fixtures/cookbooks/test_java'
+  cookbook 'freebsd_bash', path: 'test/fixtures/cookbooks/freebsd_bash'
 end

--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -29,9 +29,8 @@ when 'rhel', 'fedora'
   end
   node.default['java']['openjdk_packages'] = ["java-1.#{node['java']['jdk_version']}.0-openjdk", "java-1.#{node['java']['jdk_version']}.0-openjdk-devel"]
 when 'freebsd'
-  jdk_version = node['java']['jdk_version']
-  # FIXME guessing java_home ain't right either
   node.default['java']['java_home'] = "/usr/local/openjdk#{node['java']['jdk_version']}"
+  jdk_version = node['java']['jdk_version']
   openjdk_package = jdk_version == '7' ? 'openjdk' : "openjdk#{node['java']['jdk_version']}"
   node.default['java']['openjdk_packages'] = [openjdk_package]
 when 'arch'

--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -29,8 +29,11 @@ when 'rhel', 'fedora'
   end
   node.default['java']['openjdk_packages'] = ["java-1.#{node['java']['jdk_version']}.0-openjdk", "java-1.#{node['java']['jdk_version']}.0-openjdk-devel"]
 when 'freebsd'
+  jdk_version = node['java']['jdk_version']
+  # FIXME guessing java_home ain't right either
   node.default['java']['java_home'] = "/usr/local/openjdk#{node['java']['jdk_version']}"
-  node.default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}"]
+  openjdk_package = jdk_version == '7' ? 'openjdk' : "openjdk#{node['java']['jdk_version']}"
+  node.default['java']['openjdk_packages'] = [openjdk_package]
 when 'arch'
   node.default['java']['java_home'] = "/usr/lib/jvm/java-#{node['java']['jdk_version']}-openjdk"
   node.default['java']['openjdk_packages'] = ["openjdk#{node['java']['jdk_version']}"]

--- a/test/fixtures/cookbooks/freebsd_bash/metadata.rb
+++ b/test/fixtures/cookbooks/freebsd_bash/metadata.rb
@@ -1,0 +1,5 @@
+name             'freebsd_bash'
+maintainer       'test cookbook'
+license          'All rights reserved'
+description      'A test cookbook to install bash on freebsd for bats testing'
+version          '0.1.0'

--- a/test/fixtures/cookbooks/freebsd_bash/recipes/default.rb
+++ b/test/fixtures/cookbooks/freebsd_bash/recipes/default.rb
@@ -1,0 +1,4 @@
+# Need bash installed to use bats
+if platform_family?('freebsd')
+  package 'bash'
+end


### PR DESCRIPTION
Java 7 on freebsd doesn't work correctly, it assumes you can append `7` to `openjdk` for the package name, but openjdk defaults to version 7, and there is no package named `openjdk7`.

The other changes are to make the bats tests work on freebsd (which defaults to `csh`, not `bash`). The last test in `verify_openjdk-7.bats` fails because it assumes `/usr/bin/jar` but the package creates `/usr/local/bin/jar`.