### PR TITLE
Enable Ark provider to handle URI with get parameters

### DIFF
--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'uri'
 require 'chef/mixin/shell_out'
 include Chef::Mixin::ShellOut
 
@@ -25,7 +26,8 @@ def whyrun_supported?
 end
 
 def parse_app_dir_name(url)
-  file_name = url.split('/')[-1]
+  uri = URI.parse(url)
+  file_name = uri.path.split('/').last
   # funky logic to parse oracle's non-standard naming convention
   # for jdk1.6
   if file_name =~ /^(jre|jdk|server-jre).*$/

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -31,7 +31,7 @@ state_attrs :alternatives_priority,
             :group,
             :url
 
-attribute :url, regex: /^(file|http|https?):\/\/.*(gz|tar.gz|tgz|bin|zip)$/, default: nil
+attribute :url, kind_of: String, default: nil
 attribute :mirrorlist, kind_of: Array, default: nil
 attribute :checksum, regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/, default: nil
 attribute :md5, regex: /^[0-9a-f]{32}$|^[a-zA-Z0-9]{40,64}$/, default: nil


### PR DESCRIPTION
To our corporate blob store needs to we need pass custom get parameters to download files. This change make us to consume this cookbook.