### PR TITLE
Windows JCE support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,7 @@ when 'windows'
   default['java']['windows']['checksum'] = nil
   default['java']['windows']['package_name'] = 'Java(TM) SE Development Kit 7 (64-bit)'
   default['java']['windows']['public_jre_home'] = nil
+  default['java']['windows']['owner'] = 'administrator'
 when 'mac_os_x'
   default['java']['install_flavor'] = 'homebrew'
 else

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,6 +19,7 @@ recipe 'java::set_attributes_from_version', 'Sets various attributes that depend
 recipe 'java::set_java_home', 'Sets the JAVA_HOME environment variable'
 recipe 'java::windows', 'Installs the JDK on Windows'
 recipe 'java::homebrew', 'Installs the JDK on Mac OS X via Homebrew'
+recipe 'java::oracle_jce', 'Installs the Java Crypto Extension for strong encryption'
 
 %w(
   debian
@@ -41,10 +42,10 @@ recipe 'java::homebrew', 'Installs the JDK on Mac OS X via Homebrew'
 end
 
 depends 'apt'
+depends 'windows'
 
 source_url 'https://github.com/agileorbit-cookbooks/java' if respond_to?(:source_url)
 issues_url 'https://github.com/agileorbit-cookbooks/java/issues' if respond_to?(:issues_url)
 
 suggests 'homebrew'
-suggests 'windows'
 suggests 'aws'

--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -30,46 +30,83 @@ checksum_bin = if jce_checksum =~ /^[0-9a-f]{32}$/
                  'sha256sum'
                end
 
-package 'unzip'
-package 'curl'
-
 directory ::File.join(node['java']['oracle']['jce']['home'], jdk_version) do
   mode '0755'
   recursive true
+  action :create
 end
 
-execute 'download jce' do
-  command <<-EOF
-    rm -rf #{Chef::Config[:file_cache_path]}/java_jce
-    mkdir -p #{Chef::Config[:file_cache_path]}/java_jce
-    cd #{Chef::Config[:file_cache_path]}/java_jce
+if node['os'] == 'windows'
+  include_recipe 'windows'
 
-    curl -L --cookie '#{jce_cookie}' -o jce.zip #{jce_url}
-    # fail the resource if the checksum does not match
-    # this should only happen if oracle download terms are not accepted and downloading directly from oracle
-    echo "#{jce_checksum}  jce.zip" | #{checksum_bin} -c >/dev/null
-  EOF
-  # if jar is already in the right location then don't need to download the JCE again
-  not_if { ::File.exist?(::File.join(node['java']['oracle']['jce']['home'], jdk_version, 'US_export_policy.jar')) }
-end
+  url = node['java']['oracle']['jce'][jdk_version]['url']
+  zip_checksum = node['java']['oracle']['jce'][jdk_version]['checksum']
+  staging_path = ::File.join(node['java']['oracle']['jce']['home'], jdk_version)
+  staging_local_policy = ::File.join(staging_path, "UnlimitedJCEPolicyJDK#{jdk_version}", 'local_policy.jar')
+  staging_export_policy = ::File.join(staging_path, "UnlimitedJCEPolicyJDK#{jdk_version}", 'US_export_policy.jar')
+  jre_final_path = ::File.join(node['java']['java_home'], 'jre', 'lib', 'security')
+  final_local_policy = ::File.join(jre_final_path, 'local_policy.jar')
+  final_export_policy = ::File.join(jre_final_path, 'US_export_policy.jar')
 
-execute 'extract jce' do
-  command <<-EOF
-    unzip -o jce.zip
-    find -name '*.jar' | xargs -I JCE_JAR mv JCE_JAR #{node['java']['oracle']['jce']['home']}/#{jdk_version}/
-  EOF
-  cwd "#{Chef::Config[:file_cache_path]}/java_jce"
-  creates ::File.join(node['java']['oracle']['jce']['home'], jdk_version, 'US_export_policy.jar')
-end
-
-%w(local_policy.jar US_export_policy.jar).each do |jar|
-  jar_path = ::File.join(node['java']['java_home'], 'jre', 'lib', 'security', jar)
-  # remove the jars already in the directory
-  file jar_path do
-    action :delete
-    not_if { ::File.symlink? jar_path }
+  windows_zipfile staging_path do
+    source url
+    checksum zip_checksum
+    action :unzip
+    not_if {::File.exists? staging_local_policy}
+    notifies :create, "file[#{final_local_policy}]"
+    notifies :create, "file[#{final_export_policy}]"
   end
-  link jar_path do
-    to ::File.join(node['java']['oracle']['jce']['home'], jdk_version, jar)
+
+  file final_local_policy do
+    rights :full_control, node['java']['windows']['owner']
+    content lazy { ::File.read(staging_local_policy) }
+    action :nothing
+  end
+
+  file final_export_policy do
+    rights :full_control, node['java']['windows']['owner']
+    content lazy { ::File.read(staging_export_policy) }
+    action :nothing
+  end
+
+
+else
+  package 'unzip'
+  package 'curl'
+
+  execute 'download jce' do
+    command <<-EOF
+      rm -rf #{Chef::Config[:file_cache_path]}/java_jce
+      mkdir -p #{Chef::Config[:file_cache_path]}/java_jce
+      cd #{Chef::Config[:file_cache_path]}/java_jce
+
+      curl -L --cookie '#{jce_cookie}' -o jce.zip #{jce_url}
+      # fail the resource if the checksum does not match
+      # this should only happen if oracle download terms are not accepted and downloading directly from oracle
+      echo "#{jce_checksum}  jce.zip" | #{checksum_bin} -c >/dev/null
+    EOF
+    # if jar is already in the right location then don't need to download the JCE again
+    not_if { ::File.exist?(::File.join(node['java']['oracle']['jce']['home'], jdk_version, 'US_export_policy.jar')) }
+  end
+
+  execute 'extract jce' do
+    command <<-EOF
+      unzip -o jce.zip
+      find -name '*.jar' | xargs -I JCE_JAR mv JCE_JAR #{node['java']['oracle']['jce']['home']}/#{jdk_version}/
+    EOF
+    cwd "#{Chef::Config[:file_cache_path]}/java_jce"
+    creates ::File.join(node['java']['oracle']['jce']['home'], jdk_version, 'US_export_policy.jar')
+  end
+
+  %w(local_policy.jar US_export_policy.jar).each do |jar|
+    jar_path = ::File.join(node['java']['java_home'], 'jre', 'lib', 'security', jar)
+    # remove the jars already in the directory
+    file jar_path do
+      action :delete
+      not_if { ::File.symlink? jar_path }
+    end
+    link jar_path do
+      to ::File.join(node['java']['oracle']['jce']['home'], jdk_version, jar)
+    end
   end
 end

--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -52,7 +52,7 @@ if node['os'] == 'windows'
     source url
     checksum zip_checksum
     action :unzip
-    not_if {::File.exists? staging_local_policy}
+    not_if { ::File.exist? staging_local_policy }
     notifies :create, "file[#{final_local_policy}]"
     notifies :create, "file[#{final_export_policy}]"
   end
@@ -68,7 +68,6 @@ if node['os'] == 'windows'
     content lazy { ::File.read(staging_export_policy) }
     action :nothing
   end
-
 
 else
   package 'unzip'

--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -33,7 +33,6 @@ checksum_bin = if jce_checksum =~ /^[0-9a-f]{32}$/
 directory ::File.join(node['java']['oracle']['jce']['home'], jdk_version) do
   mode '0755'
   recursive true
-  action :create
 end
 
 if node['os'] == 'windows'

--- a/recipes/set_attributes_from_version.rb
+++ b/recipes/set_attributes_from_version.rb
@@ -19,14 +19,14 @@
 
 case node['platform_family']
 when 'rhel', 'fedora'
-  case node['java']['install_flavor']
-  when 'oracle'
-    node.default['java']['java_home'] = '/usr/lib/jvm/java'
-  when 'oracle_rpm'
-    node.default['java']['java_home'] = '/usr/java/latest'
-  else
-    node.default['java']['java_home'] = "/usr/lib/jvm/java-1.#{node['java']['jdk_version']}.0"
-  end
+  node.default['java']['java_home'] = case node['java']['install_flavor']
+                                      when 'oracle'
+                                        '/usr/lib/jvm/java'
+                                      when 'oracle_rpm'
+                                        '/usr/java/latest'
+                                      else
+                                        "/usr/lib/jvm/java-1.#{node['java']['jdk_version']}.0"
+                                      end
   node.default['java']['openjdk_packages'] = ["java-1.#{node['java']['jdk_version']}.0-openjdk", "java-1.#{node['java']['jdk_version']}.0-openjdk-devel"]
 when 'freebsd'
   node.default['java']['java_home'] = "/usr/local/openjdk#{node['java']['jdk_version']}"

--- a/spec/oracle_jce_spec.rb
+++ b/spec/oracle_jce_spec.rb
@@ -15,9 +15,9 @@ describe 'java::oracle_jce' do
     before do
       allow(::File).to receive(:read).and_call_original
       allow(::File).to receive(:read).with('c:/temp/jce/8/UnlimitedJCEPolicy8/local_policy.jar')
-                                     .and_return('local_policy.jar contents')
+        .and_return('local_policy.jar contents')
       allow(::File).to receive(:read).with('c:/temp/jce/8/UnlimitedJCEPolicy8/US_export_policy.jar')
-                                     .and_return('US_export_policy.jar contents')
+        .and_return('US_export_policy.jar contents')
     end
 
     it 'creates JCE zip file staging path' do

--- a/spec/oracle_jce_spec.rb
+++ b/spec/oracle_jce_spec.rb
@@ -1,29 +1,73 @@
 require 'spec_helper'
 
 describe 'java::oracle_jce' do
-  let(:chef_run) do
-    runner = ChefSpec::ServerRunner.new
-    runner.converge(described_recipe)
+  context 'Jar installation on Windows systems' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '2008R2') do |node|
+        node.set['java']['java_home'] = 'c:/jdk1.8'
+        node.set['java']['jdk_version'] = '8'
+        node.set['java']['oracle']['jce']['home'] = 'c:/temp/jce'
+      end
+      runner.converge(described_recipe)
+    end
+    let(:zipfile) { chef_run.windows_zipfile('c:/temp/jce/8') }
+
+    before do
+      allow(::File).to receive(:read).and_call_original
+      allow(::File).to receive(:read).with('c:/temp/jce/8/UnlimitedJCEPolicy8/local_policy.jar')
+                                     .and_return('local_policy.jar contents')
+      allow(::File).to receive(:read).with('c:/temp/jce/8/UnlimitedJCEPolicy8/US_export_policy.jar')
+                                     .and_return('US_export_policy.jar contents')
+    end
+
+    it 'creates JCE zip file staging path' do
+      expect(chef_run).to create_directory('c:/temp/jce/8')
+    end
+
+    it 'extracts JCE zip to staging path' do
+      expect(chef_run).to unzip_windows_zipfile_to('c:/temp/jce/8')
+    end
+
+    it 'zip exctraction notifies creation of local_policy.jar' do
+      expect(zipfile).to notify('file[c:/jdk1.8/jre/lib/security/local_policy.jar]')
+    end
+
+    it 'zip exctraction notifies creation of US_export_policy.jar' do
+      expect(zipfile).to notify('file[c:/jdk1.8/jre/lib/security/US_export_policy.jar]')
+    end
+
+    it 'creates local_policy.jar file resource' do
+      expect(chef_run.file('c:/jdk1.8/jre/lib/security/local_policy.jar')).to do_nothing
+    end
+
+    it 'creates US_export_policy.jar file resource' do
+      expect(chef_run.file('c:/jdk1.8/jre/lib/security/US_export_policy.jar')).to do_nothing
+    end
   end
 
-  it 'downloads the JCE zip' do
-    expect(chef_run).to run_execute('download jce')
-  end
-  it 'extracts JCE zip' do
-    expect(chef_run).to run_execute('extract jce')
-  end
-
-  it 'Installs dependencies' do
-    expect(chef_run).to install_package('unzip')
-    expect(chef_run).to install_package('curl')
-  end
-
-  context 'Jar installation' do
+  context 'Jar installation on POSIX systems' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new do |node|
         node.set['java']['java_home'] = '/usr/lib/jvm/java'
       end
       runner.converge(described_recipe)
+    end
+
+    it 'creates JCE home' do
+      expect(chef_run).to create_directory('/opt/java_jce/6')
+    end
+
+    it 'downloads the JCE zip' do
+      expect(chef_run).to run_execute('download jce')
+    end
+
+    it 'extracts JCE zip' do
+      expect(chef_run).to run_execute('extract jce')
+    end
+
+    it 'Installs dependencies' do
+      expect(chef_run).to install_package('unzip')
+      expect(chef_run).to install_package('curl')
     end
 
     it 'Deletes old jar file' do


### PR DESCRIPTION
This PR adds support for installing the Java Crypto Extensions on Windows. It works roughly similar to the Unix-like support except it relies on the JCE home (aka staging directory) to determine if the JCE Jar files need to be installed. Some other notes

* I've needed to make the cookbook depend on the "windows" cookbook for this to work
* I've added in Chefspec tests to cover as much as I can. I notice there is no current support for Windows in the Test Kitchen file. Adding Windows Test Kitchen support seems like a bigger project best done in a separate PR
* I have not bumped the version in metadata.rb as most cookbook maintainers prefer to do this themselves