### PR TITLE
Changes to prevent re-execution of resource creating file jdk.sh

### DIFF
--- a/recipes/set_java_home.rb
+++ b/recipes/set_java_home.rb
@@ -27,9 +27,8 @@ directory '/etc/profile.d' do
   mode 00755
 end
 
-file '/etc/profile.d/jdk.sh' do
-  content "export JAVA_HOME=#{node['java']['java_home']}"
-  mode 00755
+template '/etc/profile.d/jdk.sh' do
+  source "jdk.sh.erb"
 end
 
 if node['java']['set_etc_environment'] # ~FC023 -- Fails unit test to use guard

--- a/templates/default/jdk.sh.erb
+++ b/templates/default/jdk.sh.erb
@@ -1,0 +1,1 @@
+export JAVA_HOME=<%= node['java']['java_home']%>


### PR DESCRIPTION
In the current code the resource [``file '/etc/profile.d/jdk.sh'``](https://github.com/agileorbit-cookbooks/java/blob/c1952dfda48c8fe674cd9124a5f5b2158a47ce7c/recipes/set_java_home.rb#L30-L33) gets executed on every run even when there is no change. The PR is to prevent this unnecessary execution by changing it into a ``template`` resource.