### PR TITLE
Resolve chef-12 related warning

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 
 # default jdk attributes
 default['java']['jdk_version'] = '6'
-default['java']['arch'] = kernel['machine'] =~ /x86_64/ ? 'x86_64' : 'i586'
+default['java']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? 'x86_64' : 'i586'
 default['java']['openjdk_packages'] = []
 default['java']['openjdk_version'] = nil
 default['java']['accept_license_agreement'] = false


### PR DESCRIPTION
Deprecated features used!
  "method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"]) at 5 locations:
    - /var/chef/cache/cookbooks/java/attributes/default.rb:22:in `from_file'