### PR TITLE
Mac default converge fails since notify is not included by homebrew

### DIFF
--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -1,5 +1,6 @@
 include_recipe 'homebrew'
 include_recipe 'homebrew::cask'
+include_recipe 'notify'
 
 homebrew_tap 'caskroom/versions'
 homebrew_cask "java#{node['java']['jdk_version']}" do


### PR DESCRIPTION
I was trying to use java 1.41.0 in Test Kitchen using a MacOS VM and got an error from homebrew when installing the default java recipe.  It could not notify log[jdk-version-changed] because it could not find that resource.  Debugging showed that notify.rb is not included by default.rb or homebrew.rb.

Unfortunately there are no public Mac OS X boxcutter images, so I can't update the tests to validate this change, but I did confirm it fixed the problem in my personal Mac OS test kitchen environment.