### PR TITLE
Support for proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ By default, the extracted directory is extracted to
   boolean true or false
 - `use_alt_suffix`: whether '_alt' suffix is used for not default javas
   boolean true or false
-- `proxy`: address and port of proxy server, for example, `proxy.example.com:1234`
+- `proxy`: optional address and port of proxy server, for example, `proxy.example.com:1234`
 
 #### Examples
 ```ruby

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ replacing `40` with the most current version in your local repo.
 
 ### windows
 
-Because as of 26 March 2012 you can no longer directly download the 
+Because as of 26 March 2012 you can no longer directly download the
 JDK msi from Oracle's website without using a special cookie. This recipe
-requires you to set `node['java']['oracle']['accept_oracle_download_terms']` 
+requires you to set `node['java']['oracle']['accept_oracle_download_terms']`
 to true or host it internally on your own http repo or s3 bucket.
 
 **IMPORTANT NOTE**
@@ -303,6 +303,7 @@ By default, the extracted directory is extracted to
   boolean true or false
 - `use_alt_suffix`: whether '_alt' suffix is used for not default javas
   boolean true or false
+- `proxy`: address and port of proxy server, for example, `proxy.example.com:1234`
 
 #### Examples
 ```ruby

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -67,9 +67,7 @@ end
 def download_direct_from_oracle(tarball_name, new_resource)
   download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
   cookie = 'oraclelicense=accept-securebackup-cookie'
-  unless new_resource.proxy.nil?
-    proxy = "-x #{new_resource.proxy}"
-  end
+  proxy = "-x #{new_resource.proxy}" unless new_resource.proxy.nil?
   if node['java']['oracle']['accept_oracle_download_terms']
     # install the curl package
     p = package 'curl' do

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -67,6 +67,9 @@ end
 def download_direct_from_oracle(tarball_name, new_resource)
   download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
   cookie = 'oraclelicense=accept-securebackup-cookie'
+  unless new_resource.proxy.nil?
+    proxy = "-x #{new_resource.proxy}"
+  end
   if node['java']['oracle']['accept_oracle_download_terms']
     # install the curl package
     p = package 'curl' do
@@ -78,7 +81,7 @@ def download_direct_from_oracle(tarball_name, new_resource)
     converge_by(description) do
       Chef::Log.debug 'downloading oracle tarball straight from the source'
       cmd = shell_out!(
-        %( curl --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} --connect-timeout #{new_resource.connect_timeout} ),
+        %( curl --create-dirs -L --retry #{new_resource.retries} --retry-delay #{new_resource.retry_delay} --cookie "#{cookie}" #{new_resource.url} -o #{download_path} --connect-timeout #{new_resource.connect_timeout} #{proxy} ),
                                  timeout: new_resource.download_timeout
       )
     end

--- a/recipes/oracle.rb
+++ b/recipes/oracle.rb
@@ -69,6 +69,7 @@ java_ark 'jdk' do
   use_alt_suffix node['java']['use_alt_suffix']
   reset_alternatives node['java']['reset_alternatives']
   download_timeout node['java']['ark_download_timeout']
+  proxy node['java']['ark_proxy']
   action :install
   notifies :write, 'log[jdk-version-changed]', :immediately
 end

--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -49,6 +49,7 @@ attribute :connect_timeout, kind_of: Integer, default: 30 # => 30 seconds
 attribute :reset_alternatives, equal_to: [true, false], default: true
 attribute :use_alt_suffix, equal_to: [true, false], default: true
 attribute :download_timeout, kind_of: Integer, default: 600 # => 600 seconds
+attribute :proxy, kind_of: String, default: nil
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name


### PR DESCRIPTION
Added support for proxy. Usage (from [Examples](https://github.com/agileorbit-cookbooks/java#examples)):
```
name "java"
description "Install Oracle Java"
default_attributes(
  "java" => {
    "install_flavor" => "oracle",
    "jdk_version" => "7",
    "oracle" => {
      "accept_oracle_download_terms" => true
    }
    "ark_proxy" => "proxy.example.com:1234"
  }
)
run_list(
  "recipe[java]"
)
```