### PR TITLE
Create a rule for Oracle RPM for JRE installing JCE which failed linking

### DIFF
--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -88,11 +88,15 @@ else
   end
 
   %w(local_policy.jar US_export_policy.jar).each do |jar|
-    jar_path = ::File.join(node['java']['java_home'], 'jre', 'lib', 'security', jar)
+    jar_path = if node['java']['oracle_rpm']['type'] == 'jre'
+                 ::File.join(node['java']['java_home'], 'lib', 'security', jar)
+               else
+                 ::File.join(node['java']['java_home'], 'jre', 'lib', 'security', jar)
+               end
     # remove the jars already in the directory
     file jar_path do
       action :delete
-      not_if { ::File.symlink? jar_path }
+      #not_if { ::File.symlink? jar_path }
     end
     link jar_path do
       to ::File.join(node['java']['oracle']['jce']['home'], jdk_version, jar)

--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -96,7 +96,7 @@ else
     # remove the jars already in the directory
     file jar_path do
       action :delete
-      #not_if { ::File.symlink? jar_path }
+      not_if { ::File.symlink? jar_path }
     end
     link jar_path do
       to ::File.join(node['java']['oracle']['jce']['home'], jdk_version, jar)


### PR DESCRIPTION
I run into the problem when installing JCE with the following specifics:
Flavor: oracle_rpm
Type: jre
Version: 8

Basically I think this wasn't never tested using RPM and JRE so the code expected to have the directory
/usr/java/latest/jdk/jre/lib/security (but that is only for JDK installs)

but when installing JRE the path  is only 

/usr/java/latest/lib/security.

so my quick fix was to just create an if statement to handle JCE installs under JRE.

  %w(local_policy.jar US_export_policy.jar).each do |jar|
    **jar_path = if node['java']['oracle_rpm']['type'] == 'jre'**
                 ::File.join(node['java']['java_home'], 'lib', 'security', jar)
               else
                 ::File.join(node['java']['java_home'], 'jre', 'lib', 'security', jar)
               end
    # remove the jars already in the directory
    file jar_path do
      action :delete
      #not_if { ::File.symlink? jar_path }
    end
    link jar_path do
      to ::File.join(node['java']['oracle']['jce']['home'], jdk_version, jar)
    end
  end
end