### PR TITLE
Use aws session token for windows java download

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ the .tar.gz.
   checksum validation)
 * `node['java']['windows']['remove_obsolete']` - Indicates whether to remove
   previous versions of the JRE (default is `false`)
+* `node['java']['windows']['aws_access_key_id']` - AWS Acess Key ID to use with AWS API calls
+* `node['java']['windows']['aws_secret_access_key']` - AWS Secret Access Key to use with AWS API calls
+* `node['java']['windows']['aws_session_token']` - AWS Session Token to use with AWS API calls
 * `node['java']['ibm']['url']` - The URL which to download the IBM
   JDK/SDK. See the `ibm` recipe section below.
 * `node['java']['ibm']['accept_ibm_download_terms']` - Indicates that

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -27,6 +27,7 @@ Chef::Log.fatal('No download url set for java installer.') unless node['java'] &
 pkg_checksum = node['java']['windows']['checksum']
 aws_access_key_id = node['java']['windows']['aws_access_key_id']
 aws_secret_access_key = node['java']['windows']['aws_secret_access_key']
+aws_session_token = node['java']['windows']['aws_session_token']
 
 uri = ::URI.parse(node['java']['windows']['url'])
 cache_file_path = File.join(Chef::Config[:file_cache_path], File.basename(::URI.unescape(uri.path)))
@@ -37,6 +38,7 @@ if aws_access_key_id && aws_secret_access_key
   aws_s3_file cache_file_path do
     aws_access_key_id aws_access_key_id
     aws_secret_access_key aws_secret_access_key
+    aws_session_token aws_session_token
     checksum pkg_checksum if pkg_checksum
     bucket node['java']['windows']['bucket']
     remote_path node['java']['windows']['remote_path']


### PR DESCRIPTION
AWS Session Tokens are temporary credentials used for AWS API calls. In secure cloud environments these are commonly used in addition to AWS Access Key ID and AWS Secret Access Key.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html