### PR TITLE
Open JDK PPA URI set as an attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@ default['java']['jdk_version'] = '6'
 default['java']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? 'x86_64' : 'i586'
 default['java']['openjdk_packages'] = []
 default['java']['openjdk_version'] = nil
+default['java']['openjdk_ppa'] = 'ppa:openjdk-r'
 default['java']['accept_license_agreement'] = false
 default['java']['set_default'] = true
 default['java']['alternatives_priority'] = 1062

--- a/recipes/openjdk.rb
+++ b/recipes/openjdk.rb
@@ -45,7 +45,7 @@ end
 if node['platform'] == 'ubuntu'
   include_recipe 'apt'
   apt_repository 'openjdk-r-ppa' do
-    uri 'ppa:openjdk-r'
+    uri node['java']['openjdk_ppa']
     distribution node['lsb']['codename']
   end
 end


### PR DESCRIPTION
#387 Set the openjdk ppa uri as an attribute so it can be overwritten if needed.