### PR TITLE
Remove useless ruby_block[set-env-java-home]

### DIFF
--- a/recipes/set_java_home.rb
+++ b/recipes/set_java_home.rb
@@ -16,13 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ruby_block 'set-env-java-home' do
-  block do
-    ENV['JAVA_HOME'] = node['java']['java_home']
-  end
-  not_if { ENV['JAVA_HOME'] == node['java']['java_home'] }
-end
-
 directory '/etc/profile.d' do
   mode 00755
 end

--- a/spec/set_java_home_spec.rb
+++ b/spec/set_java_home_spec.rb
@@ -7,10 +7,6 @@ describe 'java::set_java_home' do
       runner.node.override['java']['java_home'] = '/opt/java'
       runner.converge(described_recipe)
     end
-    it 'it should set the java home environment variable' do
-      expect(chef_run).to run_ruby_block('set-env-java-home')
-      expect(chef_run).to_not run_ruby_block('Set JAVA_HOME in /etc/environment')
-    end
 
     it 'should create the profile.d directory' do
       expect(chef_run).to create_directory('/etc/profile.d')
@@ -18,6 +14,10 @@ describe 'java::set_java_home' do
 
     it 'should create jdk.sh with the java home environment variable' do
       expect(chef_run).to render_file('/etc/profile.d/jdk.sh').with_content('export JAVA_HOME=/opt/java')
+    end
+
+    it 'should not create /etc/environment with the java home variable' do
+      expect(chef_run).to_not run_ruby_block('Set JAVA_HOME in /etc/environment')
     end
   end
 
@@ -27,9 +27,6 @@ describe 'java::set_java_home' do
       runner.node.override['java']['java_home'] = '/opt/java'
       runner.node.override['java']['set_etc_environment'] = true
       runner.converge(described_recipe)
-    end
-    it 'it should set the java home environment variable' do
-      expect(chef_run).to run_ruby_block('set-env-java-home')
     end
 
     it 'should create the profile.d directory' do


### PR DESCRIPTION
This PR removes 'set-env-java-home' ruby_block:

* `ENV['JAVA_HOME']` within a ruby_block is scoped to that block and causes this resource to be updated on every chef run.
* More importantly: this ruby_block is not used anywhere.

cc: @erichelgeson