### PR TITLE
Update README: using java::notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ to subscribe to JDK changes and take actions (say restart a java service):
 ```ruby
 service 'somejavaservice'
   action :restart
-  subscribes :write, 'log[jdk-version-changed]', :delayed
+  subscribes :restart, 'log[jdk-version-changed]', :delayed
 end
 ```
 


### PR DESCRIPTION
Services usually don't have an action `write`. The usually `restart`.

This has nothing to do with subscribing to the `log` resource's `write`action.