### PR TITLE
Setting appropriate permissions on JCE jar files

### DIFF
--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -76,6 +76,7 @@ else
       cd java_jce
       unzip -o ../jce.zip
       find -name '*.jar' | xargs -I JCE_JAR mv JCE_JAR #{node['java']['oracle']['jce']['home']}/#{jdk_version}/
+      chmod -R 0644 #{node['java']['oracle']['jce']['home']}/#{jdk_version}/*.jar
     EOF
     cwd Chef::Config[:file_cache_path]
     creates ::File.join(node['java']['oracle']['jce']['home'], jdk_version, 'US_export_policy.jar')


### PR DESCRIPTION
The file permissions on the JCE jar files are set to 0664. As a general best practice (and as required by the NIST and DISA STIGs), library files (including jar files) should not be group or world writable and have permissions set to 0755 or less. 