### PR TITLE
Remove deprecated attributes in ark resource

### DIFF
--- a/resources/ark.rb
+++ b/resources/ark.rb
@@ -43,8 +43,6 @@ attribute :owner, default: 'root'
 attribute :group, default: nil
 attribute :default, equal_to: [true, false], default: true
 attribute :alternatives_priority, kind_of: Integer, default: 1
-attribute :retries, kind_of: Integer, default: 0
-attribute :retry_delay, kind_of: Integer, default: 2
 attribute :connect_timeout, kind_of: Integer, default: 30 # => 30 seconds
 attribute :reset_alternatives, equal_to: [true, false], default: true
 attribute :use_alt_suffix, equal_to: [true, false], default: true


### PR DESCRIPTION
In chef-client version 13 common existing resource attributes and
methods could not be overwritten in resources, which will raise
exceptions.

This commit removes :retries and :retry_delay attributes from ark
resource to prevent chef-client 13 failures.

Signed-off-by: Josep Lluis Ferrer <jlferrer.riera@gmail.com>