### PR TITLE
Update JDK download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ By default, the extracted directory is extracted to
 ```ruby
 # install jdk6 from Oracle
 java_ark "jdk" do
-    url 'http://download.oracle.com/otn-pub/java/jdk/6u29-b11/jdk-6u29-linux-x64.bin'
+    url 'http://download.oracle.com/otn/java/jdk/6u29-b11/jdk-6u29-linux-x64.bin'
     checksum  'a8603fa62045ce2164b26f7c04859cd548ffe0e33bfc979d9fa73df42e3b3365'
     app_home '/usr/local/java/default'
     bin_cmds ["java", "javac"]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,11 +99,11 @@ default['java']['jdk']['6']['bin_cmds'] = %w(appletviewer apt ControlPanel extch
                                              schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc)
 
 # x86_64
-default['java']['jdk']['6']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/6u45-b06/jdk-6u45-linux-x64.bin'
+default['java']['jdk']['6']['x86_64']['url'] = 'http://download.oracle.com/otn/java/jdk/6u45-b06/jdk-6u45-linux-x64.bin'
 default['java']['jdk']['6']['x86_64']['checksum'] = '6b493aeab16c940cae9e3d07ad2a5c5684fb49cf06c5d44c400c7993db0d12e8'
 
 # i586
-default['java']['jdk']['6']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/6u45-b06/jdk-6u45-linux-i586.bin'
+default['java']['jdk']['6']['i586']['url'] = 'http://download.oracle.com/otn/java/jdk/6u45-b06/jdk-6u45-linux-i586.bin'
 default['java']['jdk']['6']['i586']['checksum'] = 'd53b5a2518d80e1d95565f0adda54eee229dc5f4a1d1a3c2f7bf5045b168a357'
 
 # jdk7 attributes
@@ -118,11 +118,11 @@ default['java']['jdk']['7']['bin_cmds'] = %w(appletviewer apt ControlPanel extch
 # Official checksums for the latest release can be found at https://www.oracle.com/webfolder/s/digest/7u75checksum.html
 
 # x86_64
-default['java']['jdk']['7']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/7u75-b13/jdk-7u75-linux-x64.tar.gz'
+default['java']['jdk']['7']['x86_64']['url'] = 'http://download.oracle.com/otn/java/jdk/7u75-b13/jdk-7u75-linux-x64.tar.gz'
 default['java']['jdk']['7']['x86_64']['checksum'] = '6f1f81030a34f7a9c987f8b68a24d139'
 
 # i586
-default['java']['jdk']['7']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/7u75-b13/jdk-7u75-linux-i586.tar.gz'
+default['java']['jdk']['7']['i586']['url'] = 'http://download.oracle.com/otn/java/jdk/7u75-b13/jdk-7u75-linux-i586.tar.gz'
 default['java']['jdk']['7']['i586']['checksum'] = 'e4371a4fddc049eca3bfef293d812b8e'
 
 # jdk8 attributes
@@ -138,18 +138,18 @@ default['java']['jdk']['8']['bin_cmds'] = %w(appletviewer apt ControlPanel extch
 # Official checksums for the latest release can be found at https://www.oracle.com/webfolder/s/digest/8u60checksum.html
 
 # x86_64
-default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz'
+default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz'
 default['java']['jdk']['8']['x86_64']['checksum'] = '62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236'
 
 # i586
-default['java']['jdk']['8']['i586']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-i586.tar.gz'
+default['java']['jdk']['8']['i586']['url'] = 'http://download.oracle.com/otn/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-i586.tar.gz'
 default['java']['jdk']['8']['i586']['checksum'] = '2012d1c82f74bf830a80dfb5462f555b22271f74e4fc4a5779c7f459dcd0cabf'
 
 default['java']['oracle']['jce']['enabled'] = false
-default['java']['oracle']['jce']['8']['url'] = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
+default['java']['oracle']['jce']['8']['url'] = 'http://download.oracle.com/otn/java/jce/8/jce_policy-8.zip'
 default['java']['oracle']['jce']['8']['checksum'] = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
-default['java']['oracle']['jce']['7']['url'] = 'http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
+default['java']['oracle']['jce']['7']['url'] = 'http://download.oracle.com/otn/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
 default['java']['oracle']['jce']['7']['checksum'] = '7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d'
-default['java']['oracle']['jce']['6']['url'] = 'http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip'
+default['java']['oracle']['jce']['6']['url'] = 'http://download.oracle.com/otn/java/jce_policy/6/jce_policy-6.zip'
 default['java']['oracle']['jce']['6']['checksum'] = 'd0c2258c3364120b4dbf7dd1655c967eee7057ac6ae6334b5ea8ceb8bafb9262'
 default['java']['oracle']['jce']['home'] = '/opt/java_jce'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -138,18 +138,18 @@ default['java']['jdk']['8']['bin_cmds'] = %w(appletviewer apt ControlPanel extch
 # Official checksums for the latest release can be found at https://www.oracle.com/webfolder/s/digest/8u60checksum.html
 
 # x86_64
-default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz'
+default['java']['jdk']['8']['x86_64']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz'
 default['java']['jdk']['8']['x86_64']['checksum'] = '62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236'
 
 # i586
-default['java']['jdk']['8']['i586']['url'] = 'http://download.oracle.com/otn/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-i586.tar.gz'
+default['java']['jdk']['8']['i586']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-i586.tar.gz'
 default['java']['jdk']['8']['i586']['checksum'] = '2012d1c82f74bf830a80dfb5462f555b22271f74e4fc4a5779c7f459dcd0cabf'
 
 default['java']['oracle']['jce']['enabled'] = false
-default['java']['oracle']['jce']['8']['url'] = 'http://download.oracle.com/otn/java/jce/8/jce_policy-8.zip'
+default['java']['oracle']['jce']['8']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip'
 default['java']['oracle']['jce']['8']['checksum'] = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59'
-default['java']['oracle']['jce']['7']['url'] = 'http://download.oracle.com/otn/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
+default['java']['oracle']['jce']['7']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip'
 default['java']['oracle']['jce']['7']['checksum'] = '7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d'
-default['java']['oracle']['jce']['6']['url'] = 'http://download.oracle.com/otn/java/jce_policy/6/jce_policy-6.zip'
+default['java']['oracle']['jce']['6']['url'] = 'https://edelivery.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip'
 default['java']['oracle']['jce']['6']['checksum'] = 'd0c2258c3364120b4dbf7dd1655c967eee7057ac6ae6334b5ea8ceb8bafb9262'
 default['java']['oracle']['jce']['home'] = '/opt/java_jce'

--- a/providers/ark.rb
+++ b/providers/ark.rb
@@ -119,7 +119,7 @@ action :install do
       end
     end
 
-    if new_resource.url =~ /^http:\/\/download.oracle.com.*$/
+    if new_resource.url =~ /oracle\.com.*$/
       download_path = "#{Chef::Config[:file_cache_path]}/#{tarball_name}"
       if oracle_downloaded?(download_path, new_resource)
         Chef::Log.debug('oracle tarball already downloaded, not downloading again')

--- a/recipes/oracle_jce.rb
+++ b/recipes/oracle_jce.rb
@@ -22,7 +22,7 @@ include_recipe 'java::set_attributes_from_version'
 jdk_version = node['java']['jdk_version'].to_s
 jce_url = node['java']['oracle']['jce'][jdk_version]['url']
 jce_checksum = node['java']['oracle']['jce'][jdk_version]['checksum']
-jce_cookie = node['java']['oracle']['accept_oracle_download_terms'] ? 'oraclelicense=accept-securebackup-cookie;gpw_e24=http://edelivery.oracle.com' : ''
+jce_cookie = node['java']['oracle']['accept_oracle_download_terms'] ? 'oraclelicense=accept-securebackup-cookie' : ''
 
 directory ::File.join(node['java']['oracle']['jce']['home'], jdk_version) do
   mode '0755'


### PR DESCRIPTION
Oracle changed JDK download locations recently causing a global chef-run collapse for those who
 don't have their own mirror 💩 . This PR fixes https://github.com/agileorbit-cookbooks/java/issues/422.