### PR TITLE
node `bin_cmds` attr not properly set for ibm java

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ on Linux/Unix platforms, `windows` on Windows platforms.
 * `node['java']['jdk_version']` - JDK version to install, defaults to
   `'6'`.
 * `node['java']['java_home']` - Default location of the
-  "`$JAVA_HOME`".
+  "`$JAVA_HOME`". To configure this attribute for `ibm`, `ibm_tar`, and
+  `oracle_rpm` install flavors, you must use an attribute precedence of
+  `force_default` or higher in your attribute file.
 * `node['java']['set_etc_environment']` - Optionally sets
   JAVA_HOME in `/etc/environment` for  Default `false`.
 * `node['java']['openjdk_packages']` - Array of OpenJDK package names

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,36 +55,28 @@ if node['kernel']['machine'].start_with?('s390')
   default['java']['install_flavor'] = 'ibm'
 end
 
-case node['java']['install_flavor']
-when 'ibm', 'ibm_tar'
-  default['java']['ibm']['url'] = nil
-  default['java']['ibm']['checksum'] = nil
-  default['java']['ibm']['accept_ibm_download_terms'] = false
-  default['java']['java_home'] = '/opt/ibm/java'
+default['java']['ibm']['url'] = nil
+default['java']['ibm']['checksum'] = nil
+default['java']['ibm']['accept_ibm_download_terms'] = false
 
-  default['java']['ibm']['6']['bin_cmds'] = %w(appletviewer apt ControlPanel extcheck HtmlConverter idlj jar jarsigner
-                                               java javac javadoc javah javap javaws jconsole jcontrol jdb jdmpview
-                                               jrunscript keytool native2ascii policytool rmic rmid rmiregistry
-                                               schemagen serialver tnameserv wsgen wsimport xjc)
+default['java']['ibm']['6']['bin_cmds'] = %w(appletviewer apt ControlPanel extcheck HtmlConverter idlj jar jarsigner
+                                             java javac javadoc javah javap javaws jconsole jcontrol jdb jdmpview
+                                             jrunscript keytool native2ascii policytool rmic rmid rmiregistry
+                                             schemagen serialver tnameserv wsgen wsimport xjc)
 
-  default['java']['ibm']['7']['bin_cmds'] = node['java']['ibm']['6']['bin_cmds'] + %w(pack200 unpack200)
-  default['java']['ibm']['8']['bin_cmds'] = node['java']['ibm']['7']['bin_cmds']
-when 'oracle_rpm'
-  # type of java RPM : jdk or jre
-  default['java']['oracle_rpm']['type'] = 'jdk'
+default['java']['ibm']['7']['bin_cmds'] = node['java']['ibm']['6']['bin_cmds'] + %w(pack200 unpack200)
+default['java']['ibm']['8']['bin_cmds'] = node['java']['ibm']['7']['bin_cmds']
 
-  # optional, can be overriden to pin to a version different
-  # from the up-to-date.
-  default['java']['oracle_rpm']['package_version'] = nil
+# type of java RPM : jdk or jre
+default['java']['oracle_rpm']['type'] = 'jdk'
 
-  # optional, some distros re-package the official Oracle's RPM
-  # with a different name
-  default['java']['oracle_rpm']['package_name'] = nil
+# optional, can be overriden to pin to a version different
+# from the up-to-date.
+default['java']['oracle_rpm']['package_version'] = nil
 
-  # set the JAVA_HOME path, it may be overriden
-  # when a package version is provided.
-  default['java']['java_home'] = '/usr/java/latest'
-end
+# optional, some distros re-package the official Oracle's RPM
+# with a different name
+default['java']['oracle_rpm']['package_name'] = nil
 
 # if you change this to true, you can download directly from Oracle
 default['java']['oracle']['accept_oracle_download_terms'] = false

--- a/recipes/ibm.rb
+++ b/recipes/ibm.rb
@@ -20,6 +20,10 @@ require 'uri'
 
 include_recipe 'java::notify'
 
+# If you need to override this in an attribute file you must use
+# force_default or higher precedence.
+node.default['java']['java_home'] = '/opt/ibm/java'
+
 source_url = node['java']['ibm']['url']
 jdk_uri = ::URI.parse(source_url)
 jdk_filename = ::File.basename(jdk_uri.path)

--- a/recipes/ibm_tar.rb
+++ b/recipes/ibm_tar.rb
@@ -19,6 +19,10 @@ require 'uri'
 
 include_recipe 'java::notify'
 
+# If you need to override this in an attribute file you must use
+# force_default or higher precedence.
+node.default['java']['java_home'] = '/opt/ibm/java'
+
 source_url = node['java']['ibm']['url']
 jdk_uri = ::URI.parse(source_url)
 jdk_filename = ::File.basename(jdk_uri.path)

--- a/recipes/oracle_rpm.rb
+++ b/recipes/oracle_rpm.rb
@@ -17,6 +17,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# If you need to override this in an attribute file you must use
+# force_default or higher precedence.
+node.default['java']['java_home'] = '/usr/java/latest'
+
 include_recipe 'java::set_java_home'
 include_recipe 'java::notify'
 


### PR DESCRIPTION
When the `install_flavor` attribute is set to `ibm`, the attributes for
the JDK 6, 7, and 8 `bin_cmds` were not being set. This was caused by an
issue in attribute precedence.

In the `attributes/default.rb` file, the `bin_cmds` attributes were set
based on a case statement which was triggered by the `install_flavor`.
By default, the install flavor is set to `openjdk`. Based on how chef
behaves during the compilation phase, the case statement is triggered
when this attributes file is loaded which means the value of
`install_flavor` will *always* be `openjdk` at that moment so the
conditional branch for `ibm` is never invoked and thus the `bin_cmds`
attributes aren't set. Even if users `force_default` or `override` the
`install_flavor` to be `ibm` in their own cookbook.

This bug was causing the error observed in issue #271.

The fix removes the case statement completely. Since the attributes for
IBM and Oracle RPM are well scoped under `node['java']['ibm']` and
`node['java']['oracle_rpm']`