### PR TITLE
fix failing java_certificate resource under chef >= 13.0.0

### DIFF
--- a/libraries/provider_java_certificate.rb
+++ b/libraries/provider_java_certificate.rb
@@ -23,6 +23,8 @@ require 'openssl'
 require 'fileutils'
 
 class Chef::Provider::JavaCertificate < Chef::Provider::LWRPBase
+  provides :java_certificate if defined?(provides)
+
   include Chef::Mixin::ShellOut
 
   use_inline_resources


### PR DESCRIPTION
added provides to Chef::Provider::JavaCertificate